### PR TITLE
feat: add tag filters and grouping controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,18 @@
             <section id="prompts-section" class="content-section active">
                 <div class="content-with-sidebar">
                     <aside class="folders-sidebar">
-                        <h3 class="sidebar-title">フォルダ</h3>
-                        <ul id="prompt-folders" class="folders-list">
-                            <!-- フォルダアイテムが動的に追加されます -->
-                        </ul>
+                        <div class="sidebar-section">
+                            <h3 class="sidebar-title">フォルダ</h3>
+                            <ul id="prompt-folders" class="folders-list">
+                                <!-- フォルダアイテムが動的に追加されます -->
+                            </ul>
+                        </div>
+                        <div class="sidebar-section">
+                            <h3 class="sidebar-title">タグ</h3>
+                            <ul id="prompt-tags" class="tags-list">
+                                <!-- タグフィルタが動的に追加されます -->
+                            </ul>
+                        </div>
                     </aside>
 
                     <div class="content-main">
@@ -56,6 +64,13 @@
                                     <option value="title-desc">タイトル (Z→A)</option>
                                 </select>
                             </div>
+                            <div class="group-box">
+                                <select id="prompt-grouping" class="sort-select">
+                                    <option value="none">グループ化: なし</option>
+                                    <option value="folder">フォルダでグループ化</option>
+                                    <option value="tag">タグでグループ化</option>
+                                </select>
+                            </div>
                             <div class="toolbar-actions">
                                 <button type="button" class="btn btn-secondary json-export-btn" id="prompt-export-btn">JSONエクスポート</button>
                                 <label for="json-import-input" class="btn btn-secondary json-import-label">JSONインポート</label>
@@ -73,10 +88,18 @@
             <section id="contexts-section" class="content-section">
                 <div class="content-with-sidebar">
                     <aside class="folders-sidebar">
-                        <h3 class="sidebar-title">フォルダ</h3>
-                        <ul id="context-folders" class="folders-list">
-                            <!-- フォルダアイテムが動的に追加されます -->
-                        </ul>
+                        <div class="sidebar-section">
+                            <h3 class="sidebar-title">フォルダ</h3>
+                            <ul id="context-folders" class="folders-list">
+                                <!-- フォルダアイテムが動的に追加されます -->
+                            </ul>
+                        </div>
+                        <div class="sidebar-section">
+                            <h3 class="sidebar-title">タグ</h3>
+                            <ul id="context-tags" class="tags-list">
+                                <!-- タグフィルタが動的に追加されます -->
+                            </ul>
+                        </div>
                     </aside>
 
                     <div class="content-main">
@@ -95,6 +118,14 @@
                                     <option value="date-asc">作成日 (古い順)</option>
                                     <option value="title-asc">タイトル (A→Z)</option>
                                     <option value="title-desc">タイトル (Z→A)</option>
+                                </select>
+                            </div>
+                            <div class="group-box">
+                                <select id="context-grouping" class="sort-select">
+                                    <option value="none">グループ化: なし</option>
+                                    <option value="folder">フォルダでグループ化</option>
+                                    <option value="category">カテゴリでグループ化</option>
+                                    <option value="tag">タグでグループ化</option>
                                 </select>
                             </div>
                             <div class="toolbar-actions">
@@ -166,6 +197,10 @@
                     <div class="form-group">
                         <label for="context-category">カテゴリ</label>
                         <input type="text" id="context-category" placeholder="例: 技術知識, ビジネス, デザイン">
+                    </div>
+                    <div class="form-group">
+                        <label for="context-tags">タグ (カンマ区切り)</label>
+                        <input type="text" id="context-tags" placeholder="例: テンプレート, ガイド, チーム共有">
                     </div>
                     <div class="form-group">
                         <label for="context-folder">フォルダ</label>

--- a/styles.css
+++ b/styles.css
@@ -331,6 +331,59 @@ body::before {
     margin: 0;
 }
 
+.sidebar-section + .sidebar-section {
+    margin-top: var(--spacing-xl);
+    padding-top: var(--spacing-lg);
+    border-top: var(--border-width) solid var(--neutral-100);
+}
+
+.tags-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.tag-filter-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    padding: calc(var(--spacing-xs) * 0.75) var(--spacing-md);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: all var(--transition-base);
+    color: var(--neutral-600);
+    font-size: 0.875rem;
+    margin-bottom: var(--spacing-xs);
+}
+
+.tag-filter-item:hover {
+    background: var(--neutral-100);
+    color: var(--neutral-700);
+}
+
+.tag-filter-item.active {
+    background: var(--accent-50);
+    color: var(--accent-700);
+    font-weight: 600;
+}
+
+.tag-name {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tag-count {
+    background: var(--neutral-100);
+    color: var(--neutral-500);
+    border-radius: var(--radius-full);
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
 .folder-item {
     display: flex;
     align-items: center;
@@ -490,6 +543,10 @@ body::before {
     flex-shrink: 0;
 }
 
+.group-box {
+    flex-shrink: 0;
+}
+
 .sort-select {
     padding: var(--spacing-lg) var(--spacing-xl);
     font-size: 0.9375rem;
@@ -523,6 +580,45 @@ body::before {
     grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: var(--spacing-lg);
     animation: fadeIn 0.5s ease-out;
+}
+
+.items-grid.is-grouped {
+    display: block;
+    animation: fadeIn 0.5s ease-out;
+}
+
+.group-section {
+    margin-bottom: var(--spacing-2xl);
+}
+
+.group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+}
+
+.group-title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--neutral-800);
+    letter-spacing: -0.01em;
+}
+
+.group-count {
+    background: var(--neutral-100);
+    color: var(--neutral-500);
+    border-radius: var(--radius-full);
+    padding: 0.125rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.group-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--spacing-lg);
 }
 
 /* ========================================
@@ -707,6 +803,12 @@ body::before {
 }
 
 .tag:hover {
+    background: var(--accent-50);
+    color: var(--accent-700);
+    border-color: var(--accent-200);
+}
+
+.tag-category {
     background: var(--accent-50);
     color: var(--accent-700);
     border-color: var(--accent-200);


### PR DESCRIPTION
## Summary
- add sidebar tag filters and grouping selectors to navigate prompts and contexts more easily
- extend storage and editing flows to support context tags alongside folders and preview metadata
- refresh styling for tag lists and grouped layouts to match the existing interface design

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e635397de483218387b10b6771a6e1